### PR TITLE
Eliminate jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
     <title>5e - GWM/SS AC Threshold Calculator</title>
     <!-- CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css">
-    <!-- JS preload-->
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 </head>
 <body>
 <header class="container header">

--- a/main.js
+++ b/main.js
@@ -43,22 +43,16 @@ function get_thresh(hit, dmg, adv) {
 }
 
 function compute() {
-    let adv = $("#adv3").is(":checked") ? 3 : $("#adv2").is(":checked") ? 2 : ($("#adv1").is(":checked") ? 1 : 0);
-    let hit = $("#hit_bonus").val();
-    let dmg = $("#damage").val();
-    $("#res-field").text(get_thresh(hit, dmg, adv));
+    let adv = document.querySelector("#adv3").checked ? 3 : document.querySelector("#adv2").checked ? 2 : (document.querySelector("#adv1").checked ? 1 : 0);
+    let hit = document.querySelector("#hit_bonus").value;
+    let dmg = document.querySelector("#damage").value;
+    document.querySelector("#res-field").innerText = get_thresh(hit, dmg, adv);
 }
 
-var tt;
-
-$(".ref").on("keyup", function(){
-    clearTimeout(tt);
-    tt = setTimeout(compute, 1000);
-});
-
-$(".r_ref").on("change", function(){
-    clearTimeout(tt);
-    compute();
+document.body.addEventListener('input', function(event) {
+    if (event.target.classList.contains('r_ref') || event.target.classList.contains('ref')) {
+        setTimeout(compute, 0);
+    }
 });
 
 compute();


### PR DESCRIPTION
Hello there! I hope you don't mind, but here's a PR that eliminates the need to load jQuery. This should help the page load a bit faster. It also condenses the two previous events (keyup and change) into one more-universal event (input) to keep the page more responsive as users change the form field values.